### PR TITLE
ignoreAltitude now working

### DIFF
--- a/ARCL/Source/Nodes/LocationNode.swift
+++ b/ARCL/Source/Nodes/LocationNode.swift
@@ -107,8 +107,6 @@ open class LocationNode: SCNNode {
 
         let adjustedDistance: CLLocationDistance
         if locationConfirmed && (distance > 100 || continuallyAdjustNodePositionWhenWithinRange || setup) {
-            let locationTranslation = location.translation(toLocation: self.location(locationManager.bestLocationEstimate))
-
             if distance > 100 {
                 //If the item is too far away, bring it closer and scale it down
                 let scale = 100 / Float(distance)


### PR DESCRIPTION
Ignore altitude feature now working, but I noticed that there is a problem when SceneLocationView is loaded.
```
Main Thread Checker: UI API called on a background thread: -[UIApplication applicationState]
PID: 6827, TID: 1912939, Thread name: com.apple.CoreMotion.MotionThread, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   libobjc.A.dylib                     0x000000023242f6f4 <redacted> + 56
5   CoreMotion                          0x0000000238ba9d9c CoreMotion + 294300
6   CoreMotion                          0x0000000238baa2cc CoreMotion + 295628
7   CoreMotion                          0x0000000238baa1dc CoreMotion + 295388
8   CoreMotion                          0x0000000238bd801c CoreMotion + 483356
9   CoreMotion                          0x0000000238bd8060 CoreMotion + 483424
10  CoreFoundation                      0x00000002331be27c <redacted> + 28
11  CoreFoundation                      0x00000002331bdb64 <redacted> + 276
12  CoreFoundation                      0x00000002331b8e58 <redacted> + 2276
13  CoreFoundation                      0x00000002331b8254 CFRunLoopRunSpecific + 452
14  CoreFoundation                      0x00000002331b8f88 CFRunLoopRun + 84
15  CoreMotion                          0x0000000238bd79f4 CoreMotion + 481780
16  libsystem_pthread.dylib             0x0000000232e36908 <redacted> + 132
17  libsystem_pthread.dylib             0x0000000232e36864 _pthread_start + 48
18  libsystem_pthread.dylib             0x0000000232e3edcc thread_start + 4
```