### PR TITLE
Update syntax

### DIFF
--- a/ARKit+CoreLocation/LocationCell.swift
+++ b/ARKit+CoreLocation/LocationCell.swift
@@ -73,15 +73,15 @@ private extension MKMapItem {
         if let name = name {
             result += name
         }
-        if let addressDictionary = placemark.addressDictionary {
-            if let street = addressDictionary["Street"] as? String {
-                result += "\n\(street)"
-            }
-            if let city = addressDictionary["City"] as? String,
-                let state = addressDictionary["State"] as? String,
-                let zip = addressDictionary["ZIP"] as? String {
-                result += "\n\(city), \(state) \(zip)"
-            }
+        if let street = placemark.thoroughfare {
+            result += "\n\(street)"
+        }
+        if
+            let city = placemark.locality,
+            let state = placemark.administrativeArea,
+            let zip = placemark.postalCode,
+            let country = placemark.country {
+            result += String(format: "\n%@, %@ %@ \n%@", city, state, zip, country)
         } else if let location = placemark.location {
             result += "\n\(location.coordinate)"
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+- 1.2.2
+    - Update `MapKit` extension's `titleLabelText` syntax.
 - 1.2.1
     - [PR #207 - Addresses Issue #136 - ARCL lacks CI ](https://github.com/ProjectDent/ARKit-CoreLocation/pull/207)
     - [PR #209 - Updates polyline position/scale when GPS location is updated](https://github.com/ProjectDent/ARKit-CoreLocation/pull/209)


### PR DESCRIPTION
### Background

`LocationCell`, at present, uses `addressDictionary` to pull address information off a `MKMapItem`'s `placemark` via `addressDictionary`. This PR updates the syntax to obviate the need for hard-coded strings to pull values out of the dictionary.

### Breaking Changes
No breaking changes should be introduced by this PR.

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [x] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->